### PR TITLE
release 1.1.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ to `find python
 executables <https://testrun.org/tox/latest/plugins.html#tox.hookspecs.tox_get_python_executable>`__
 
 Your project's `circle.yml <https://circleci.com/docs/configuration>`__
-#########################################################################
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In order for ``tox`` to have the versions of python you want available,
 set them using
@@ -24,12 +24,11 @@ set them using
 
 The versions passed to ``pyenv local`` must be
 `installed <https://github.com/yyuu/pyenv/blob/master/COMMANDS.md#pyenv-install>`__
-for this to work. Check out the list of python versions that are
-pre-installed in the CircleCI build environment:
-https://circleci.com/docs/environment#python
+for this to work. See `CircleCI Preinstalled Python
+Versions <#circleci-preinstalled-python-versions>`__ for a list.
 
 Corresponding `tox.ini <https://tox.readthedocs.org/en/latest/config.html>`__
-###############################################################################
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code:: ini
 
@@ -42,7 +41,7 @@ versions of python have been
 `pyenv install <https://github.com/yyuu/pyenv/blob/master/COMMANDS.md#pyenv-install>`__\ed.
 
 notes
-########
+^^^^^
 
 If you want tox to *exclusively* use ``pyenv which`` to find
 executables, you will need use the ``--tox-pyenv-no-fallback`` command
@@ -50,8 +49,56 @@ line option, or set ``tox_pyenv_fallback=False`` in your tox.ini. By
 default, if ``tox-pyenv`` fails to find a python executable it will
 fallback to tox's built-in strategy.
 
+CircleCI Preinstalled Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Here is the list of python versions that are *pre-installed* in the
+CircleCI build environment (as of 09/27/2017):
+
+::
+
+    $ pyenv versions
+      system
+      2.6.6
+      2.6.8
+      2.7
+      2.7.10
+      2.7.11
+      2.7.3
+      2.7.4
+      2.7.5
+      2.7.6
+      2.7.7
+      2.7.8
+    * 2.7.9 (set by /home/ubuntu/.pyenv/version)
+      3.1.5
+      3.2
+      3.2.5
+      3.3.0
+      3.3.2
+      3.3.3
+      3.4.0
+      3.4.1
+      3.4.2
+      3.4.3
+      3.5.0
+      pypy-2.2.1
+      pypy-2.3.1
+      pypy-2.4.0
+      pypy-2.5.0
+
+If the version you need isn't in the list, such as Python ``3.6-dev``
+include an ``install`` step:
+
+::
+
+    dependencies:
+      override:
+        - pip install tox tox-pyenv
+        - pyenv install --skip-existing 3.6-dev
+        - pyenv local 3.6-dev
+
 .. |latest| image:: https://img.shields.io/pypi/v/tox-pyenv.svg
    :target: https://pypi.python.org/pypi/tox-pyenv
 .. |Circle CI| image:: https://circleci.com/gh/samstav/tox-pyenv/tree/master.svg?style=shield
    :target: https://circleci.com/gh/samstav/tox-pyenv/tree/master
-

--- a/tox_pyenv.py
+++ b/tox_pyenv.py
@@ -33,7 +33,7 @@ __title__ = 'tox-pyenv'
 __summary__ = ('tox plugin that makes tox use `pyenv which` '
                'to find python executables')
 __url__ = 'https://github.com/samstav/tox-pyenv'
-__version__ = '1.0.3'
+__version__ = '1.1.0'
 __author__ = 'Sam Stavinoha'
 __email__ = 'smlstvnh@gmail.com'
 __keywords__ = ['tox', 'pyenv', 'python']


### PR DESCRIPTION
3b38e60 :heavy_minus_sign: bump to 1.1.0 :small_blue_diamond: Sam Stavinoha
09bc593 :heavy_minus_sign: update README.rst :small_blue_diamond: Sam Stavinoha
214b88e :heavy_minus_sign: Fix link :small_blue_diamond: Sam Stavinoha
e3c71e2 :heavy_minus_sign: remove official support for python 3.2 :small_blue_diamond: Sam Stavinoha
959da59 :heavy_minus_sign: update README :small_blue_diamond: Sam Stavinoha
5a3a169 :heavy_minus_sign: remove dependency constraints :small_blue_diamond: Sam Stavinoha
a6dca3c :heavy_minus_sign: lint :small_blue_diamond: Sam Stavinoha
cbfabd9 :heavy_minus_sign: use newer version of python 2.7.x during tests :small_blue_diamond: Sam Stavinoha
98e7268 :heavy_minus_sign: add style checks during tests :small_blue_diamond: Sam Stavinoha
d997ba8 :heavy_minus_sign: add test for 'dont kill tox run if..' :small_blue_diamond: Sam Stavinoha
0a6199f :heavy_minus_sign: dont kill tox run if pyenv is not installed :small_blue_diamond: Sam Stavinoha